### PR TITLE
User now receives server 403 instead of 500 when manually entering 'd…

### DIFF
--- a/notes_on_issues/084_filament_instance_delete_view_change.md
+++ b/notes_on_issues/084_filament_instance_delete_view_change.md
@@ -1,0 +1,28 @@
+# `FilamentInstanceDeleteView` only when no `ModelPrint`
+
+## Resources:
+
+## Current UX:
+
+1. User enters URL `prints/filament-instances/2/delete/` manually since link doesn't show on web page:
+
+1. User is presented dialog with `Confirm Delete` button:
+
+1. User clicks `Confirm Delete` button:
+
+1. User is presented `Server Error (500)`:
+
+## Proposed resolution:
+
+1. Add check `not hasattr(filament_instance, 'print')` to `test_func()`:
+    ```
+    def test_func(self):
+        filament_instance = self.get_object()
+        return (
+            # User is `FilamentRoll` `owner`:
+            self.request.user == filament_instance.filament_roll.owner
+            and
+            # `FilamentInstance` has no associated `ModelPrint`s:
+            not hasattr(filament_instance, 'print')
+        )
+    ```

--- a/prints/views.py
+++ b/prints/views.py
@@ -169,13 +169,14 @@ class FilamentInstanceDeleteView(LoginRequiredMixin, UserPassesTestMixin, Delete
     def test_func(self):
         filament_instance = self.get_object()
         print('filament_instance: ', filament_instance)
-        if hasattr(filament_instance, 'print'):
-            print("FilamentInstance deletion possible: False")
-            print('filament_instance.print: ', filament_instance.print)
-            print('bool(filament_instance.print): ', bool(filament_instance.print))
-        if not hasattr(filament_instance, 'print'):
-            print("FilamentInstance deletion possible: True")
-        return self.request.user == filament_instance.filament_roll.owner
+        print(f"FilamentInstance deletion possible: {not hasattr(filament_instance, 'print')}")
+        return (
+            # User is `FilamentRoll` `owner`:
+            self.request.user == filament_instance.filament_roll.owner
+            and
+            # `FilamentInstance` has no associated `ModelPrint`s:
+            not hasattr(filament_instance, 'print')
+        )
 
 #================================================================
 


### PR DESCRIPTION
…elete' endpoint.